### PR TITLE
feat: Implement custom heart rate zone settings API

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -25,11 +25,11 @@ This file outlines the development steps and serves as a checklist to track prog
         - [x] Create or update `User` record in the database.
         - [x] Implement basic session/token management for *our* backend.
     - [x] Add URL patterns for auth views.
-- [ ] **Custom Zone Settings API**
-    - [ ] Implement `GET /api/zones/settings` view (retrieve settings for logged-in user).
-    - [ ] Implement `POST /api/zones/settings` view (create/update settings for logged-in user).
-    - [ ] Add URL patterns for settings views.
-    - [ ] Add serializers (DRF) for `CustomZoneSetting`.
+- [x] **Custom Zone Settings API**
+    - [x] Implement `GET /api/zones/settings` view (retrieve settings for logged-in user).
+    - [x] Implement `POST /api/zones/settings` view (create/update settings for logged-in user).
+    - [x] Add URL patterns for settings views.
+    - [x] Add serializers (DRF) for `CustomZoneSetting`.
 
 ## Phase 2: Backend Core Logic
 

--- a/strava_zones_backend/api/serializers.py
+++ b/strava_zones_backend/api/serializers.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rest_framework import serializers
+
+from api.models import CustomZonesConfig, HeartRateZone
+
+if TYPE_CHECKING:
+	from typing import Any
+
+
+class HeartRateZoneSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = HeartRateZone
+		fields = ["id", "name", "min_hr", "max_hr", "order"]
+		read_only_fields = ["id"]
+
+
+class CustomZonesConfigSerializer(serializers.ModelSerializer):
+	zones_definition = HeartRateZoneSerializer(many=True)
+	user = serializers.PrimaryKeyRelatedField(read_only=True)
+	activity_type = serializers.ChoiceField(
+		choices=CustomZonesConfig.ActivityType.choices, required=True
+	)
+
+	class Meta:
+		model = CustomZonesConfig
+		fields = ["id", "user", "activity_type", "zones_definition", "created_at", "updated_at"]
+		read_only_fields = ["id", "created_at", "updated_at"]
+
+	def create(self, validated_data: dict[str, Any]) -> CustomZonesConfig:
+		zones_data = validated_data.pop("zones_definition")
+		# Associate with the authenticated user, not from payload
+		user = self.context["request"].user.strava_profile
+		config = CustomZonesConfig.objects.create(user=user, **validated_data)
+		for zone_data in zones_data:
+			HeartRateZone.objects.create(config=config, **zone_data)
+		return config
+
+	def update(
+		self, instance: CustomZonesConfig, validated_data: dict[str, Any]
+	) -> CustomZonesConfig:
+		zones_data = validated_data.pop("zones_definition", None)
+
+		instance.activity_type = validated_data.get("activity_type", instance.activity_type)
+		instance.save()
+
+		if zones_data is not None:
+			# Simple approach: delete existing and create new ones
+			# More sophisticated updates could match by ID or order
+			instance.zones_definition.all().delete()
+			for zone_data in zones_data:
+				HeartRateZone.objects.create(config=instance, **zone_data)
+
+		return instance

--- a/strava_zones_backend/api/urls.py
+++ b/strava_zones_backend/api/urls.py
@@ -8,4 +8,9 @@ urlpatterns = [
 	path("profile/", views.user_profile, name="user_profile"),
 	path("auth/strava/", views.strava_authorize, name="strava_authorize"),
 	path("auth/strava/callback/", views.strava_callback, name="strava_callback"),
+	path(
+		"zones/settings/",
+		views.CustomZonesSettingsView.as_view(),
+		name="zone_settings_list_create",
+	),
 ]


### PR DESCRIPTION
Adds GET and POST endpoints for /api/zones/settings/ allowing users to define and retrieve their custom heart rate zone configurations.